### PR TITLE
Generate Content with JSON response schema #3

### DIFF
--- a/src/main/java/io/kestra/plugin/gemini/StructuredOutputCompletion.java
+++ b/src/main/java/io/kestra/plugin/gemini/StructuredOutputCompletion.java
@@ -1,0 +1,119 @@
+package io.kestra.plugin.gemini;
+
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Generate Structured JSON Output Using the Gemini Client.",
+    description = "See [Gemini API about structured output completion](https://ai.google.dev/gemini-api/docs/structured-output) for more information."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Structured JSON Output Completion using the Gemini Client.",
+            full = true,
+            code = """
+                id: gemini_structured_json_completion
+                namespace: company.team
+
+                tasks:
+                  - id: gemini_structured_json_completion
+                    type: io.kestra.plugin.gemini.StructuredOutputCompletion
+                    apiKey: ${{ secrets.GEMINI_API_KEY }}
+                    model: "gemini-2.5-flash-preview-05-20"
+                    prompt: What are the weather predictions for tomorrow in London?
+                    jsonResponseSchema: |
+                        {
+                            "type": "object",
+                            "properties": {
+                                "predictions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "content": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                """
+        )
+    }
+)
+public class StructuredOutputCompletion extends AbstractGemini implements RunnableTask<StructuredOutputCompletion.Output> {
+
+    private static final String APPLICATION_JSON = "application/json";
+    @Schema(title = "Prompt")
+    @NotNull
+    private Property<String> prompt;
+
+    @Schema(title = "jsonResponseSchema")
+    @NotNull
+    private Property<String> jsonResponseSchema;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+
+        var renderedApiKey = runContext.render(apiKey).as(String.class).orElseThrow();
+        var renderedModel = runContext.render(model).as(String.class).orElseThrow();
+        var renderedPrompt = runContext.render(prompt).as(String.class).orElseThrow();
+        var responseSchema = runContext.render(jsonResponseSchema).as(String.class).orElseThrow();
+
+
+        try (var client = Client.builder().apiKey(renderedApiKey).build()) {
+            // Configure generation settings, including the response schema and MIME type
+            final GenerateContentConfig generationConfig = GenerateContentConfig.builder()
+                .responseMimeType(APPLICATION_JSON)
+                .responseSchema(com.google.genai.types.Schema.fromJson(responseSchema))
+                .build();
+
+            final GenerateContentResponse responses = client.models.generateContent(renderedModel, renderedPrompt, generationConfig);
+
+            sendMetrics(runContext, responses.usageMetadata().map(List::of).orElse(List.of()));
+
+            final List<String> predictions = Objects.nonNull(responses.parts()) ?
+                responses.parts().stream()
+                    .map(Part::text)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .toList() : List.of();
+            return StructuredOutputCompletion.Output.builder()
+                .predictions(predictions)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "List of text predictions made by the model.")
+        private List<String> predictions;
+    }
+}

--- a/src/main/java/io/kestra/plugin/gemini/StructuredOutputCompletion.java
+++ b/src/main/java/io/kestra/plugin/gemini/StructuredOutputCompletion.java
@@ -70,6 +70,7 @@ import java.util.Optional;
 public class StructuredOutputCompletion extends AbstractGemini implements RunnableTask<StructuredOutputCompletion.Output> {
 
     private static final String APPLICATION_JSON = "application/json";
+
     @Schema(title = "Prompt")
     @NotNull
     private Property<String> prompt;

--- a/src/test/java/io/kestra/plugin/gemini/StructuredOutputCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/gemini/StructuredOutputCompletionTest.java
@@ -118,7 +118,7 @@ class StructuredOutputCompletionTest {
             .apiKey(Property.ofValue(GEMINI_API_KEY))
             .model(Property.ofValue(GEMINI_2_5_FLASH_PREVIEW_05_20))
             .prompt(Property.ofValue("List a few popular cookie recipes, and include the amounts of ingredients?"))
-            .jsonResponseSchema(Property.ofValue("" +
+            .jsonResponseSchema(Property.ofValue(
                 """
                     {
                         "type": "object",

--- a/src/test/java/io/kestra/plugin/gemini/StructuredOutputCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/gemini/StructuredOutputCompletionTest.java
@@ -29,7 +29,7 @@ class StructuredOutputCompletionTest {
             .apiKey(Property.ofValue(GEMINI_API_KEY))
             .model(Property.ofValue(GEMINI_2_5_FLASH_PREVIEW_05_20))
             .prompt(Property.ofValue("List a few popular cookie recipes, and include the amounts of ingredients?"))
-            .jsonResponseSchema(Property.ofValue("" +
+            .jsonResponseSchema(Property.ofValue(
                 """
                     {
                        "type": "ARRAY",
@@ -65,7 +65,7 @@ class StructuredOutputCompletionTest {
             .apiKey(Property.ofValue(GEMINI_API_KEY))
             .model(Property.ofValue(GEMINI_2_5_FLASH_PREVIEW_05_20))
             .prompt(Property.ofValue("List a few popular cookie recipes, and include the amounts of ingredients?"))
-            .jsonResponseSchema(Property.ofValue("" +
+            .jsonResponseSchema(Property.ofValue(
                 """
                      {
                         "type": "object",

--- a/src/test/java/io/kestra/plugin/gemini/StructuredOutputCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/gemini/StructuredOutputCompletionTest.java
@@ -1,0 +1,144 @@
+package io.kestra.plugin.gemini;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+@KestraTest
+class StructuredOutputCompletionTest {
+    private static final String GEMINI_API_KEY = System.getenv("GEMINI_API_KEY");
+    private static final String GEMINI_2_5_FLASH_PREVIEW_05_20 = "gemini-2.5-flash-preview-05-20";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".*")
+    void structuredOutputCompletion() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var structuredOutputCompletionBuilder = StructuredOutputCompletion.builder()
+            .apiKey(Property.ofValue(GEMINI_API_KEY))
+            .model(Property.ofValue(GEMINI_2_5_FLASH_PREVIEW_05_20))
+            .prompt(Property.ofValue("List a few popular cookie recipes, and include the amounts of ingredients?"))
+            .jsonResponseSchema(Property.ofValue("" +
+                """
+                    {
+                       "type": "ARRAY",
+                       "items": {
+                         "type": "OBJECT",
+                         "properties": {
+                           "recipeName": { "type": "STRING" },
+                           "ingredients": {
+                             "type": "ARRAY",
+                             "items": { "type": "STRING" }
+                           }
+                         },
+                         "propertyOrdering": ["recipeName", "ingredients"]
+                       }
+                     }
+
+                    """
+            ))
+            .build();
+
+        var output = structuredOutputCompletionBuilder.run(runContext);
+        assertThat(output.getPredictions().toString(), containsString("recipeName"));
+        assertThat(output.getPredictions().toString(), containsString("ingredients"));
+        assertThat(output.getPredictions().toString(), containsString("\"recipeName\":"));
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".*")
+    void structuredOutputCompletion_withSimpleStructure() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var structuredOutputCompletionBuilder = StructuredOutputCompletion.builder()
+            .apiKey(Property.ofValue(GEMINI_API_KEY))
+            .model(Property.ofValue(GEMINI_2_5_FLASH_PREVIEW_05_20))
+            .prompt(Property.ofValue("List a few popular cookie recipes, and include the amounts of ingredients?"))
+            .jsonResponseSchema(Property.ofValue("" +
+                """
+                     {
+                        "type": "object",
+                        "properties": {
+                            "predictions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "content": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    """
+            ))
+            .build();
+
+        final var output = structuredOutputCompletionBuilder.run(runContext);
+        assertThat(output.getPredictions().toString(), containsString("predictions"));
+        assertThat(output.getPredictions().toString(), containsString("content"));
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".*")
+    void structuredOutputCompletion_givenNoJsonResponseStructure_shouldThrowException() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var structuredOutputCompletionBuilder = StructuredOutputCompletion.builder()
+            .apiKey(Property.ofValue(GEMINI_API_KEY))
+            .model(Property.ofValue(GEMINI_2_5_FLASH_PREVIEW_05_20))
+            .prompt(Property.ofValue("List a few popular cookie recipes, and include the amounts of ingredients?"))
+            .build();
+
+
+        var exception = Assertions.assertThrows(Exception.class, () -> structuredOutputCompletionBuilder.run(runContext));
+        assertThat(exception.getMessage(), containsString("No value present"));
+    }
+
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".*")
+    void structuredOutputCompletion_givenInvalidJsonStructure_shouldThrowException() throws Exception {
+        var runContext = runContextFactory.of();
+        var structuredOutputCompletionBuilderWithInvalidJson = StructuredOutputCompletion.builder()
+            .apiKey(Property.ofValue(GEMINI_API_KEY))
+            .model(Property.ofValue(GEMINI_2_5_FLASH_PREVIEW_05_20))
+            .prompt(Property.ofValue("List a few popular cookie recipes, and include the amounts of ingredients?"))
+            .jsonResponseSchema(Property.ofValue("" +
+                """
+                    {
+                        "type": "object",
+                        "properties": {
+                            "predictions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "content": {
+                                            "type": "string"
+                                    }
+                                        // Missing closing brace for "properties" and "items"
+                            }
+                        }
+                    """)
+            )
+            .build();
+
+        var exception = Assertions.assertThrows(Exception.class, () -> structuredOutputCompletionBuilderWithInvalidJson.run(runContext));
+        assertThat(exception.getMessage(), containsString("Failed to deserialize the JSON string."));
+    }
+}


### PR DESCRIPTION

Integrated with As an additional feature for this plugin, it could be interesting to be able to [format the response with a JSON schema (official Java lib doc)](https://github.com/googleapis/java-genai/?tab=readme-ov-file#generate-content-with-json-response-schema)


```
id: gemini_structured_json_completion
namespace: company.team

tasks:
  - id: gemini_structured_json_completion
    type: io.kestra.plugin.gemini.StructuredOutputCompletion
    apiKey: ${{ secrets.GEMINI_API_KEY }}
    model: "gemini-2.5-flash-preview-05-20"
    prompt:  What are the weather predictions for tomorrow in London? 
    jsonResponseSchema: |
      {
        "type": "object",
        "properties": {
          "predictions": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "content": {
                  "type": "string"
                }
              },
              "required": ["content"]
            }
          }
        },
        "required": ["predictions"]
      }

```