### PR TITLE
fix: publish snapshots to central.sonatype.com instead of s01.oss.sonatype.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     if (isBuildSnapshot) {
-        maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
     }
 }
 


### PR DESCRIPTION
- part-of: https://github.com/kestra-io/kestra-ee/issues/7375